### PR TITLE
Add \gram mass unit

### DIFF
--- a/siunitx.cwl
+++ b/siunitx.cwl
@@ -118,6 +118,7 @@
 
 # Prefixed and abbreviated units
 # Masses
+\gram
 \kilogram
 \kg
 \femtogram


### PR DESCRIPTION
\gram macro is defined in siunitx.sty but missing in cwl.