### PR TITLE
Fix formatting for textins command

### DIFF
--- a/csquotes.cwl
+++ b/csquotes.cwl
@@ -98,7 +98,8 @@
 \textelp{text}
 \textelp*{text}
 
-\textins{text} \textins*{text}
+\textins{text}
+\textins*{text}
 
 # Configuration
 


### PR DESCRIPTION
There are two variants of the `\textins` command, which are not properly recognized by code editors if they are on the same line in the `csqoutes.cwl` file